### PR TITLE
fixing update related bug and adding support for clean_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The `user` attributes are used to populate the config file (ossec.conf) and prel
 * `node['ossec']['user']['active_response']` - Whether to enable active response feature of OSSEC, default true. It is safe and recommended to leave this enabled.
 * `node['ossec']['user']['syscheck']` - Whether to enable the integrity checking process, syscheck. Default true. It is safe and recommended to leave this enabled.
 * `node['ossec']['user']['rootcheck']` - Whether to enable the rootkit checking process, rootcheck. Default true. It is safe and recommended to leave this enabled.
+* `node['ossec']['user']['clean_install']` - Whether a clean installation should be done, default false.
 * `node['ossec']['user']['update']` - Whether an update installation should be done, default false.
 * `node['ossec']['user']['update_rules']` - Whether to update rules files, default true.
 * `node['ossec']['user']['binary_install']` - If true, use the binaries in the bin directory rather than compiling. Default false. The cookbook doesn't yet support binary installations.

--- a/templates/default/preloaded-vars.conf.erb
+++ b/templates/default/preloaded-vars.conf.erb
@@ -22,15 +22,14 @@ USER_ENABLE_ROOTCHECK="y"
 <% else -%>
 USER_ENABLE_ROOTCHECK="n"
 <% end -%>
+<% if @ossec['clean_install'] -%>
+USER_CLEANINSTALL="y"
+<% end -%>
 <% if @ossec['update'] -%>
 USER_UPDATE="y"
-<% else -%>
-USER_UPDATE="n"
 <% end -%>
 <% if @ossec['update_rules'] -%>
 USER_UPDATE_RULES="y"
-<% else -%>
-USER_UPDATE_RULES="n"
 <% end -%>
 <% if @ossec['binary_install'] -%>
 USER_BINARYINSTALL="x"


### PR DESCRIPTION
According to the ossec unattended installation docs, setting USER_UPDATE or USER_UPDATE_RULES to any value will be interpreted as true.  So the preloaded-vars.conf.erb template has been modified to omit these instead of setting them to "n".

Because of this these attributes cannot explicitly be set to false.  So, there is also a USER_CLEANINSTALL option which support has been added for in the preloaded-vars.conf.erb template.

From http://ossec-docs.readthedocs.org/en/latest/manual/installation/install-source-unattended.html :

    # If USER_UPDATE is set to anything, the update
    # installation will be done.
    #USER_UPDATE="y"

    # If USER_UPDATE_RULES is set to anything, the
    # rules will also be updated.
    #USER_UPDATE_RULES="y"