### PR TITLE
give scp (for distributing keys) a timeout attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,7 +35,7 @@ default['ossec']['data_bag']['ssh']        = "ssh"
 
 # server-only
 default['ossec']['server']['maxagents'] = 256
-default['ossec']['server']['scp']['timeout'] = 30
+default['ossec']['server']['scp']['timeout'] = nil
 
 # used to populate config files and preload values for install
 default['ossec']['user']['language'] = "en"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['ossec']['data_bag']['ssh']        = "ssh"
 
 # server-only
 default['ossec']['server']['maxagents'] = 256
+default['ossec']['server']['scp']['timeout'] = 30
 
 # used to populate config files and preload values for install
 default['ossec']['user']['language'] = "en"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ default['ossec']['url']         = "http://www.ossec.net/files/ossec-hids-#{node[
 default['ossec']['logs']        = []
 default['ossec']['syscheck_freq'] = 79200
 default['ossec']['disable_config_generation'] = false
+default['ossec']['email_alert_level']   = "7"
 
 # data bag configuration
 default['ossec']['data_bag']['encrypted']  = false

--- a/templates/default/dist-ossec-keys.sh.erb
+++ b/templates/default/dist-ossec-keys.sh.erb
@@ -5,6 +5,6 @@ for host in <%= @ssh_hosts.join(' ') %>
 do
   key=`mktemp`
   grep $host <%= node['ossec']['user']['dir'] %>/etc/client.keys > $key
-  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %> -o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end <%> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
+  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %> -o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
   rm $key
 done

--- a/templates/default/dist-ossec-keys.sh.erb
+++ b/templates/default/dist-ossec-keys.sh.erb
@@ -5,6 +5,6 @@ for host in <%= @ssh_hosts.join(' ') %>
 do
   key=`mktemp`
   grep $host <%= node['ossec']['user']['dir'] %>/etc/client.keys > $key
-  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B -o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
+  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %> -o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end <%> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
   rm $key
 done

--- a/templates/default/dist-ossec-keys.sh.erb
+++ b/templates/default/dist-ossec-keys.sh.erb
@@ -5,6 +5,6 @@ for host in <%= @ssh_hosts.join(' ') %>
 do
   key=`mktemp`
   grep $host <%= node['ossec']['user']['dir'] %>/etc/client.keys > $key
-  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %> -o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
+  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %>-o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
   rm $key
 done

--- a/templates/default/dist-ossec-keys.sh.erb
+++ b/templates/default/dist-ossec-keys.sh.erb
@@ -5,6 +5,6 @@ for host in <%= @ssh_hosts.join(' ') %>
 do
   key=`mktemp`
   grep $host <%= node['ossec']['user']['dir'] %>/etc/client.keys > $key
-  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %>-o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end %>-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
+  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %>-o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
   rm $key
 done

--- a/templates/default/dist-ossec-keys.sh.erb
+++ b/templates/default/dist-ossec-keys.sh.erb
@@ -5,6 +5,6 @@ for host in <%= @ssh_hosts.join(' ') %>
 do
   key=`mktemp`
   grep $host <%= node['ossec']['user']['dir'] %>/etc/client.keys > $key
-  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %>-o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
+  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B <% if node['ossec']['server']['scp']['timeout'] %>-o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> <% end %>-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
   rm $key
 done

--- a/templates/default/dist-ossec-keys.sh.erb
+++ b/templates/default/dist-ossec-keys.sh.erb
@@ -5,6 +5,6 @@ for host in <%= @ssh_hosts.join(' ') %>
 do
   key=`mktemp`
   grep $host <%= node['ossec']['user']['dir'] %>/etc/client.keys > $key
-  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
+  scp -i <%= node['ossec']['user']['dir'] %>/.ssh/id_rsa -B -o ConnectTimeout=<%= node['ossec']['server']['scp']['timeout'] %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossecd@$host:<%= node['ossec']['user']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
   rm $key
 done

--- a/templates/default/ossec.conf.erb
+++ b/templates/default/ossec.conf.erb
@@ -140,7 +140,7 @@
 <% end -%>
   <alerts>
     <log_alert_level>1</log_alert_level>
-    <email_alert_level>7</email_alert_level>
+    <email_alert_level><%= node[:ossec][:email_alert_level] %></email_alert_level>
   </alerts>
 
   <command>


### PR DESCRIPTION
I have a handful of nodes that are administratively down in aws and I'd like to be able to tweak the timeout settings for the key distribution script. Just pulled 30 seconds out of my rear as a default. 