### PR TITLE
Add notify_time and time-reconnect for v2.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The `user` attributes are used to populate the config file (ossec.conf) and prel
 * `node['ossec']['user']['firewall_response']` - Enable or disable the firewall response which sets up firewall rules for blocking. Default is true.
 * `node['ossec']['user']['pf']` - Enable PF firewall on BSD, default is false.
 * `node['ossec']['user']['pf_table']` - The PF table to use on BSD. Default is false, set this to the desired table if enabling `pf`.
+* `node['ossec']['user']['white_list']` - Array of additional IP addresses to white list. Default is empty.
 * `node['ossec']['user']['notify_time']` - Specifies the time in seconds between information messages sent by the agents to the server. Default is 600 seconds. (Available only with version 2.7.1 or later)
 * `node['ossec']['user']['time-reconnect']` - Time in seconds until a reconnection attempt. This should be set to a higher number than notify_time. Default is 900 seconds. (Available only with version 2.7.1 or later)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The `user` attributes are used to populate the config file (ossec.conf) and prel
 * `node['ossec']['user']['firewall_response']` - Enable or disable the firewall response which sets up firewall rules for blocking. Default is true.
 * `node['ossec']['user']['pf']` - Enable PF firewall on BSD, default is false.
 * `node['ossec']['user']['pf_table']` - The PF table to use on BSD. Default is false, set this to the desired table if enabling `pf`.
-* `node['ossec']['user']['white_list']` - Array of additional IP addresses to white list. Default is empty.
+* `node['ossec']['user']['notify_time']` - Specifies the time in seconds between information messages sent by the agents to the server. Default is 600 seconds. (Available only with version 2.7.1 or later)
+* `node['ossec']['user']['time-reconnect']` - Time in seconds until a reconnection attempt. This should be set to a higher number than notify_time. Default is 900 seconds. (Available only with version 2.7.1 or later)
 
 These attributes are used to setup the OSSEC Web UI.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,8 @@ default['ossec']['user']['firewall_response'] = true
 default['ossec']['user']['pf'] = false
 default['ossec']['user']['pf_table'] = false
 default['ossec']['user']['white_list'] = []
+default['ossec']['user']['notify_time'] = 600
+default['ossec']['user']['time-reconnect'] = 900
 
 # web-ui only
 default['ossec']['wui']['checksum']     = "142febadfd4b0de5a13ebd93c13eedfbee5f1899b6ee71c248054c14f47b8089"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,7 +59,10 @@ template "#{node['ossec']['user']['dir']}/etc/ossec.conf" do
   owner "root"
   group "ossec"
   mode 0440
-  variables(:ossec => node['ossec']['user'])
+  variables(
+    :ossec => node['ossec']['user'],
+    :version => node['ossec']['version']
+  )
   notifies :restart, "service[ossec]"
   not_if { node['ossec']['disable_config_generation'] }
 end

--- a/templates/default/ossec.conf.erb
+++ b/templates/default/ossec.conf.erb
@@ -18,6 +18,10 @@
 <% if @ossec['install_type'] == 'agent' -%>
   <client>
     <server-ip><%= @ossec['agent_server_ip'] %></server-ip>
+    <% unless :version == "2.7" -%>
+    <notify_time><%= @ossec['notify_time'] %></notify_time>
+    <time-reconnect><%= @ossec['time-reconnect'] %></time-reconnect>
+    <% end -%>
   </client>
 
 <% end -%>
@@ -85,13 +89,13 @@
     <include>ossec_rules.xml</include>
     <include>attack_rules.xml</include>
     <include>local_rules.xml</include>
-  </rules>  
+  </rules>
 
   <% if @ossec['syscheck'] -%>
   <syscheck>
     <!-- Frequency that syscheck is executed - default to every 22 hours -->
     <frequency><%= node['ossec']['syscheck_freq'] %></frequency>
-    
+
     <!-- Directories to check  (perform all possible verifications) -->
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories check_all="yes">/bin,/sbin</directories>


### PR DESCRIPTION
Version 2.7.1 introduced 2 new tunables for agents: "notify_time" and "time-reconnect"
This PR serves to add them to the ossec cookbook for those that wish to use version 2.7.1 or higher.  Currently this cookbook defaults to 2.7.

Change source:
http://www.ossec.net/files/ossec-hids-2.7.1-release-note.txt