### PR TITLE
Add support for multiple cloud providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Default values are based on the defaults from OSSEC's own install.sh installatio
 * `node['ossec']['data_bag']['name']` - The name of the data bag to use
 * `node['ossec']['data_bag']['ssh']` - The name of the data bag item which contains the OSSEC keys
 * `node['ossec']['server']['maxagents']` - Maximum number of agents, default setting is 256, but will be set to 1024 in the ossec::server recipe if used. Add as an override attribute in the `ossec_server` role if more nodes are required.
+* `node['ossec']['server']['cloud_public_addr']` - Under default configuration, OSSEC will use `node.ipaddress` to map IP's to chef nodes. Enabling this attribute will cause it to use `node.cloud.public_ips` instead. If the node is not in the cloud, it will fall back to `node.ipaddress`
 * `node['ossec']['disable_config_generation']` - Boolean that dictates whether this cookbook should drop the ossec.conf template or not. This is useful if you're using a wrapper cookbook and would like to generate your own template.
 
 The `user` attributes are used to populate the config file (ossec.conf) and preload values for the installation script.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['ossec']['data_bag']['ssh']        = "ssh"
 
 # server-only
 default['ossec']['server']['maxagents'] = 256
+default['ossec']['server']['cloud_public_addr'] = false
 
 # used to populate config files and preload values for install
 default['ossec']['user']['language'] = "en"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -26,7 +26,11 @@ if node.run_list.roles.include?(node['ossec']['server_role'])
   ossec_server << node['ipaddress']
 else
   search(:node, search_string) do |n|
-    ossec_server << n['ipaddress']
+    if n['ossec']['server']['cloud_public_addr'] && n['cloud']
+      ossec_server << n['cloud']['public_ips'].first
+    else
+      ossec_server << n['ipaddress']
+    end
   end
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -32,10 +32,16 @@ search_string << " NOT role:#{node['ossec']['server_role']}"
 
 search(:node, search_string) do |n|
 
-  ssh_hosts << n['ipaddress'] if n['keys']
+  if node['ossec']['server']['cloud_public_addr'] && n['cloud']
+    ipaddress = n['cloud']['public_ips'].first
+  else
+    ipaddress = n['ipaddress']
+  end
 
-  execute "#{agent_manager} -a --ip #{n['ipaddress']} -n #{n['fqdn'][0..31]}" do
-    not_if "grep '#{n['fqdn'][0..31]} #{n['ipaddress']}' #{node['ossec']['user']['dir']}/etc/client.keys"
+  ssh_hosts << ipaddress if n['keys']
+
+  execute "#{agent_manager} -a --ip #{ipaddress} -n #{n['fqdn'][0..31]}" do
+    not_if "grep '#{n['fqdn'][0..31]} #{ipaddress}' #{node['ossec']['user']['dir']}/etc/client.keys"
   end
 
 end


### PR DESCRIPTION
This serves to fix the merge conflicts in https://github.com/jtimberman/ossec-cookbook/pull/13

Info from PR #13:

When running OSSEC on an infrastructure that spans multiple cloud providers, using node.ipaddress is not effective as the hosted machine is frequently NAT'd. This results in the clients trying to use a private address to communicate with the OSSEC server on a different network.

In order to work around this problem, I'd like to introduce an attribute which will instruct the recipes to consult the node's cloud attribute in order to obtain public addresses. This allows the infrastructure to span multiple cloud providers. Since most providers have reachability on both public and private addresses, there should be no caveats other than a change in the network route.

Default is disabled for backward compatibility.