### PR TITLE
Revisit chef code to support 2.8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin
 .kitchen/
 .kitchen.local.yml
 Berksfile.lock
+*.iml
+.idea/

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 
 # general settings
 default['ossec']['server_role'] = "ossec_server"
+default['ossec']['client_role'] = "ossec_client"
 default['ossec']['server_env']  = nil
 default['ossec']['checksum']    = "f8ac4a7d74068a8ca4f14e3c906bfa3a68a87fd026b463422bea79fe9d747249"
 default['ossec']['version']     = "2.7"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,7 @@ default['ossec']['user']['update_rules'] = true
 default['ossec']['user']['binary_install'] = false
 default['ossec']['user']['agent_server_ip'] = nil
 default['ossec']['user']['enable_email'] = true
+default['ossec']['user']['enable_zabbix_integration'] = false
 default['ossec']['user']['email'] = "ossec@example.com"
 default['ossec']['user']['smtp'] = "127.0.0.1"
 default['ossec']['user']['remote_syslog'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,7 @@ default['ossec']['user']['firewall_response'] = true
 default['ossec']['user']['pf'] = false
 default['ossec']['user']['pf_table'] = false
 default['ossec']['user']['white_list'] = []
+default['ossec']['user']['zabbix_alert_level'] = 8
 
 # web-ui only
 default['ossec']['wui']['checksum']     = "142febadfd4b0de5a13ebd93c13eedfbee5f1899b6ee71c248054c14f47b8089"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,7 +50,6 @@ default['ossec']['user']['update_rules'] = true
 default['ossec']['user']['binary_install'] = false
 default['ossec']['user']['agent_server_ip'] = nil
 default['ossec']['user']['enable_email'] = true
-default['ossec']['user']['enable_zabbix_integration'] = false
 default['ossec']['user']['email'] = "ossec@example.com"
 default['ossec']['user']['smtp'] = "127.0.0.1"
 default['ossec']['user']['remote_syslog'] = false
@@ -58,7 +57,14 @@ default['ossec']['user']['firewall_response'] = true
 default['ossec']['user']['pf'] = false
 default['ossec']['user']['pf_table'] = false
 default['ossec']['user']['white_list'] = []
-default['ossec']['user']['zabbix_alert_level'] = 8
+
+# External alerting
+default['ossec']['user']['enable_zabbix_integration'] = false
+default['ossec']['user']['zabbix_alert_level'] = 1
+default['ossec']['user']['enable_syslog_integration'] = false
+default['ossec']['user']['syslog_server_address'] = ''
+default['ossec']['user']['syslog_server_port'] = 514
+default['ossec']['user']['syslog_alert_level'] = 1
 
 # web-ui only
 default['ossec']['wui']['checksum']     = "142febadfd4b0de5a13ebd93c13eedfbee5f1899b6ee71c248054c14f47b8089"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -70,3 +70,9 @@ file "#{node['ossec']['user']['dir']}/etc/client.keys" do
   group "ossec"
   mode 0660
 end
+
+log 'restart ossec service' do
+  notifies :restart, 'service[ossec]', :immediately
+  # This avoids failure when converging the first time when server has not scp'ed keys yet.
+  only_if "test -s #{node['ossec']['user']['dir']}/etc/client.keys"
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,7 +60,6 @@ template "#{node['ossec']['user']['dir']}/etc/ossec.conf" do
   group "ossec"
   mode 0440
   variables(:ossec => node['ossec']['user'])
-  notifies :restart, "service[ossec]"
   not_if { node['ossec']['disable_config_generation'] }
 end
 
@@ -75,5 +74,7 @@ end
 
 service "ossec" do
   supports :status => true, :restart => true
-  action [:enable, :start]
+  # had to remove start to support 2.8.3. Server and client recipe will
+  # notify restart immediately later on when client.keys is in place.
+  action [:enable]
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -32,7 +32,7 @@ agent_manager = "#{node['ossec']['user']['dir']}/bin/ossec-batch-manager.pl"
 
 ssh_hosts = Array.new
 
-search_string = "ossec:[* TO *]"
+search_string = "roles:#{node['ossec']['client_role']}"
 Chef::Log.debug("search_string:#{search_string}")
 
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -22,6 +22,13 @@ node.set['ossec']['server']['maxagents']  = 1024
 
 include_recipe "ossec"
 
+# External syslog alerting service has to be enabled before restarting ossec service, if configured
+if node['ossec']['user']['enable_syslog_integration']
+  execute 'enable syslog client' do
+    command "#{node['ossec']['user']['dir']}/bin/ossec-control enable client-syslog"
+  end
+end
+
 # It's hard to create robust conditionals here, see also
 # http://tickets.opscode.com/browse/COOK-1828
 log 'restart ossec service' do

--- a/templates/default/ossec.conf.erb
+++ b/templates/default/ossec.conf.erb
@@ -137,11 +137,27 @@
     <system_audit>/var/ossec/etc/shared/cis_rhel5_linux_rcl.txt</system_audit>
   </rootcheck>
 
-<% end -%>
+
   <alerts>
     <log_alert_level>1</log_alert_level>
     <email_alert_level>7</email_alert_level>
   </alerts>
+
+<% if @ossec['enable_zabbix_integration'] -%>
+  <command>
+    <name>zabbix-alert</name>
+    <executable>zabbix-alert.sh</executable>
+    <timeout_allowed>no</timeout_allowed>
+    <expect></expect>
+  </command>
+
+  <active-response>
+    <disabled>no</disabled>
+    <command>zabbix-alert</command>
+    <location>server</location>
+    <level>1</level>
+  </active-response>
+<% end -%>
 
   <command>
     <name>host-deny</name>

--- a/templates/default/ossec.conf.erb
+++ b/templates/default/ossec.conf.erb
@@ -141,6 +141,12 @@
     <level><%= @ossec['zabbix_alert_level'] %></level>
   </active-response>
 <% end -%>
+<% if @ossec['enable_syslog_integration'] -%>
+  <syslog_output>
+    <level><%= @ossec['syslog_alert_level'] %></level>
+    <server><%= @ossec['syslog_server_address'] %></server>
+    <port><%= @ossec['syslog_server_port'] %></port>
+  </syslog_output>
 <% if @ossec['rootcheck'] -%>
   <rootcheck>
     <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>

--- a/templates/default/ossec.conf.erb
+++ b/templates/default/ossec.conf.erb
@@ -147,6 +147,7 @@
     <server><%= @ossec['syslog_server_address'] %></server>
     <port><%= @ossec['syslog_server_port'] %></port>
   </syslog_output>
+<% end -%>
 <% if @ossec['rootcheck'] -%>
   <rootcheck>
     <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>

--- a/templates/default/ossec.conf.erb
+++ b/templates/default/ossec.conf.erb
@@ -125,24 +125,7 @@
     <ignore>C:\WINDOWS/system32/spool</ignore>
     <ignore>C:\WINDOWS/system32/CatRoot</ignore>
   </syscheck>
-
 <% end -%>
-<% if @ossec['rootcheck'] -%>
-  <rootcheck>
-    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
-    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
-    <system_audit>/var/ossec/etc/shared/system_audit_rcl.txt</system_audit>
-    <system_audit>/var/ossec/etc/shared/cis_debian_linux_rcl.txt</system_audit>
-    <system_audit>/var/ossec/etc/shared/cis_rhel_linux_rcl.txt</system_audit>
-    <system_audit>/var/ossec/etc/shared/cis_rhel5_linux_rcl.txt</system_audit>
-  </rootcheck>
-
-
-  <alerts>
-    <log_alert_level>1</log_alert_level>
-    <email_alert_level>7</email_alert_level>
-  </alerts>
-
 <% if @ossec['enable_zabbix_integration'] -%>
   <command>
     <name>zabbix-alert</name>
@@ -158,6 +141,20 @@
     <level>1</level>
   </active-response>
 <% end -%>
+<% if @ossec['rootcheck'] -%>
+  <rootcheck>
+    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
+    <system_audit>/var/ossec/etc/shared/system_audit_rcl.txt</system_audit>
+    <system_audit>/var/ossec/etc/shared/cis_debian_linux_rcl.txt</system_audit>
+    <system_audit>/var/ossec/etc/shared/cis_rhel_linux_rcl.txt</system_audit>
+    <system_audit>/var/ossec/etc/shared/cis_rhel5_linux_rcl.txt</system_audit>
+  </rootcheck>
+<% end -%>
+  <alerts>
+    <log_alert_level>1</log_alert_level>
+    <email_alert_level>7</email_alert_level>
+  </alerts>
 
   <command>
     <name>host-deny</name>

--- a/templates/default/ossec.conf.erb
+++ b/templates/default/ossec.conf.erb
@@ -138,7 +138,7 @@
     <disabled>no</disabled>
     <command>zabbix-alert</command>
     <location>server</location>
-    <level>1</level>
+    <level><%= @ossec['zabbix_alert_level'] %></level>
   </active-response>
 <% end -%>
 <% if @ossec['rootcheck'] -%>


### PR DESCRIPTION
Changes needed for 2.8.3 to work out of the box.
- client.keys has now to be in place and populated by server before its Start/restart
- Added some debug statements for the agent discovery via chef search
- Moved some start/restart actions downhill, in wrapper client/server
  recipes as it makes more sense (at least to me)